### PR TITLE
Allow passing args to create-quasar

### DIFF
--- a/create-quasar/README.md
+++ b/create-quasar/README.md
@@ -22,6 +22,14 @@ pnpm create quasar
 bun create quasar
 ```
 
+### Non-interactive usage
+
+You can pass answers as command line flags to skip the interactive prompts:
+
+```bash
+npm init quasar -- --projectType app --projectFolder my-app --name my-app --engine vite-2
+```
+
 ## Supporting Quasar
 
 Quasar Framework is an MIT-licensed open source project. Its ongoing development is made possible thanks to the support by these awesome [backers](https://github.com/rstoenescu/quasar-framework/blob/dev/backers.md).

--- a/create-quasar/index.js
+++ b/create-quasar/index.js
@@ -2,6 +2,7 @@
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
+import prompts from 'prompts'
 
 // display banner
 console.log()
@@ -26,6 +27,28 @@ const argv = parseArgs(process.argv.slice(2), {
 
   boolean: [ 'n' ],
 })
+
+// prepare prompt overrides from CLI parameters
+if ('_' in argv) {
+  delete argv._
+}
+if ('n' in argv) {
+  argv.nogit = argv.n
+  delete argv.n
+}
+for (const [ key, val ] of Object.entries(argv)) {
+  if (Array.isArray(val)) {
+    argv[key] = val.flatMap(v => typeof v === 'string' && v.includes(',')
+      ? v.split(',')
+      : v)
+  }
+  else if (typeof val === 'string') {
+    if (val === 'true') argv[key] = true
+    else if (val === 'false') argv[key] = false
+    else if (val.includes(',')) argv[key] = val.split(',')
+  }
+}
+prompts.override(argv)
 
 const defaultProjectFolder = 'quasar-project'
 const scope = {}


### PR DESCRIPTION
## Summary
- support command line parameters in create-quasar
- document how to use create-quasar non-interactively

## Testing
- `pnpm --filter create-quasar lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_683ac9fa4de883228d4bd214e95698f9